### PR TITLE
added InputHook reset on mouse click

### DIFF
--- a/CallTipsForAll_AHKv2.ahk
+++ b/CallTipsForAll_AHKv2.ahk
@@ -39,11 +39,11 @@ return ; end of auto execute section
 class oCallTip { ; testing
 	Static srcFiles := "", c := ""
 	Static captureKeys := "abcdefghijklmnopqrstuvwxyz1234567890.,-=/'\[]{{}{}}{Space}{Backspace}{Up}{Down}{Left}{Right}"
-	Static colNum := 0, lineNum := 0, lineText := "" ; hide
+	Static colNum := 0, lineNum := 0, lineText := ""
 	Static scintBufferLen := 0, suppressEnter := false
 	
 	; properties for call display and help link
-	Static curIndex := "", fullDescArr := Map(), helpFile := "" ; hide
+	Static curIndex := "", fullDescArr := Map(), helpFile := ""
 	
 	; properties for parent window and editor control
 	Static ctlHwnd := 0, progHwnd := 0, progTitle := "", ctlActive := false, ctlConfirmed := false

--- a/LibV2/_LoadElements.ahk
+++ b/LibV2/_LoadElements.ahk
@@ -116,6 +116,11 @@ CheckMouseLocation() {
 		oCallTip.ctlActive := false
 	Else
 		oCallTip.ctlActive := true
+	
+	If (!oCallTip.ctlActive) {
+		IH.Stop()
+		SetupInputHook(false)
+	}
 }
 
 ; ==================================================


### PR DESCRIPTION
* mouse click, when not in editor window, will reset InputHook and set suppression of {Enter} and {Tab} to false, just to be sure.