### PR TITLE
disable everything when settings is open

### DIFF
--- a/CallTipsForAll_AHKv2.ahk
+++ b/CallTipsForAll_AHKv2.ahk
@@ -164,8 +164,8 @@ Down:: ; scroll when multiple records are available for call tips
 		; clipboard := newText
 ; }
 
-; F11:: ; list custom functions, commands, and objects - for debugging List_*.txt files only
-; {
+F11:: ; list custom functions, commands, and objects - for debugging List_*.txt files only
+{
 	; testList := ""
 	; For curFunc, obj in FunctionList {
 		; params := obj["desc"]
@@ -203,7 +203,9 @@ Down:: ; scroll when multiple records are available for call tips
 	; }
 	; A_Clipboard := testList
 	; MsgBox "Classes loaded:`r`n`r`n" testList
-; }
+	
+	; A_Clipboard :=   
+}
 
 ; F10:: ; list functions - for debugging List_*.txt files only
 ; {
@@ -277,16 +279,16 @@ SetupInputHook(suppressEnter) {
 keyPress(iHook,VK,SC) { ; InputHook ;ZZZ - significant changes here...
 	a := WinActive("ahk_id " oCallTip.progHwnd) ; check if editor control is active
 	b := AutoCompleteGUI.HasProp("hwnd") ? WinActive("ahk_id " AutoCompleteGUI.hwnd) : 0 ; check if auto-complete is active
+	c := SettingsGUI.HasProp("hwnd") ? WinActive("ahk_id " SettingsGUI.hwnd) : 0
 	
-	If (vk = 9 And GetKeyState("Alt") Or (!a And !b))	; if alt-tab editor control is inactive
+	If ((vk = 9 And GetKeyState("Alt")) Or (!a And !b) Or c)	; if alt-tab editor control is inactive
 		oCallTip.ctlActive := false
 	Else If (a Or b) 								; if a > 0 then editor control is active
 		oCallTip.ctlActive := true
 	
-	ProcInput()
-	curPhrase := oCallTip.curPhrase, parentObj := oCallTip.parentObj
-	
 	If (oCallTip.ctlActive) { ; populate or clear KeywordFilter based on .ctlActive
+		ProcInput()
+		curPhrase := oCallTip.curPhrase, parentObj := oCallTip.parentObj
 		KeywordFilter := KwSearchDeep(curPhrase, parentObj)
 	} Else {
 		KeywordFilter.Clear()

--- a/Languages/AHK1/Other/List_Regex.txt
+++ b/Languages/AHK1/Other/List_Regex.txt
@@ -1,9 +1,16 @@
-FunctionStart: ^([\w]+)(\x28.*?\x29)[ \t\r\n]*\{
-FunctionEnd: \r?\n(\})
+FunctionStart: ([\w]+)(\x28[^\x29]*\x29)[ \t\r\n]*\{
+FunctionEnd: (\})
 FunctionReturn: ^[ \t]*return[ \t]+([\w]+)
-ClassStart: ^class ([\w]+)[ \t\r\n]*\{|^class ([\w]+) extends ([\w\.]+)[ \t\r\n]*\{
-ClassEnd: \r?\n(\})
-Method: ^[ \t]*([\w]+)(\(.*\))([ \t\r\n]*\{)
-Property: ^[ \t]*([\w]+)(\[.*?\])?[ \t\r\n]*(\=\>|\{)
-ClassInstance: ^[ \t]*([\w\.]+)[ \t]*\:\=[ \t]*new {Class}(\x28.*?\x29)
+ClassStart: class ([\w]+)( extends ([\w\.]+))?[ \t\r\n]*\{
+ClassEnd: (\})
+MethodStart: ^[ \t]*(Static[ \t]+)?([\w\.]+)(\x28.*\x29)[ \t\r\n]*\{
+MethodEnd: \}
+MethodOneLine: ^[ \t]*(Static[ \t]+)?([\w\.]+)(\x28.*\x29)[ \t]*\=\>.+
+PropertyStart: ^[ \t]*(Static[ \t]+)?([\w\.]+)(\[.*?\])?[ \t\r\n]*\{
+PropertyEnd: \}
+PropertyOneLine: ^[ \t]*(Static[ \t]+)?([\w\.]+)(\x5B[^\x5D]*\x5D)?[ \t]*\=\>.+
+SmallPropExt: (([\w]+)[ \t]*\:\=)[^\;\r\n]*(\;.*)?
+SmallPropInt: this\.([\w]+)[ \t]*\:\=[^\;\r\n]*(\;.*)?
+ClassInstance: ([\w\.]+)[ \t]*\:\=[ \t]*New[ \t]*{Class}(\x28.*?\x29)
 Includes: ^(#Include(Again)?[ \t]+.*)
+LineComment: (\;.*)

--- a/LibV2/_LoadElements.ahk
+++ b/LibV2/_LoadElements.ahk
@@ -32,6 +32,7 @@ ReloadElements() {
 	
 	curDocText := ControlGetText(oCallTip.ctlHwnd) ;get text from current doc in editor
 	
+	; msgbox "parse includes"
 	If (FileExist(Settings["BaseFile"])) { ;or use content of base file and all its includes instead
 		pos := 0, tmp := ""
 		For i, File in GetIncludes() {
@@ -59,14 +60,19 @@ ReloadElements() {
 		
 		; msgbox testStr
 	}
+	; msgbox "done parsing includes"
 	
 	oCallTip.docTextNoStr := StringOutline(curDocText) ; this should only be done once per load/reload (for full text + includes)
 	oCallTip.docText := curDocText
 	
 	CustomFunctions := GetCustomFunctions(curDocText)
+	; msgbox "in1"
 	ClassesList := GetClasses(curDocText)
+	; msgbox "in2"
 	ScanClasses(curDocText)
+	; msgbox "in3"
 	ObjectList := CreateObjList(curDocText)
+	; msgbox "done parsing"
 }
 
 ; ==================================================
@@ -649,12 +655,13 @@ GetLineNum(inPos) { ; DocumentMap.Push(Map("fileName",File, "lineNum",lineNum, "
 }
 
 GetCustomFunctions(curDocText) { ;ZZZ - this should work better
+	; msgbox "curDocText:`r`n`r`n" curDocText
 	curDocTextNoStr := oCallTip.docTextNoStr
 	funcList := Map(), funcList.CaseSense := 0 ;ZZZ - keeping CaseSense on so we can correct case on auto-complete
 	curPos1 := 1
 	
 	While (result := RegExMatch(curDocTextNoStr,"mi)" oCallTip.funcStart,match,curPos1)) {
-		funcName := "", bodyText := ""
+		funcName := "", bodyText := "", obj := Map()
 		If (IsObject(match) And match.Count()) {
 			curPos1 := match.Pos(0)
 			funcName := match.Value(1)
@@ -665,6 +672,7 @@ GetCustomFunctions(curDocText) { ;ZZZ - this should work better
 			curPos2 := curPos1
 			While (r2 := RegExMatch(curDocTextNoStr,"mi)" oCallTip.funcEnd,match2,curPos2)) {
 				bodyText := SubStr(curDocTextNoStr,curPos1,match2.Pos(0)+match2.Len(0)-curPos1)
+				; msgbox bodyText
 				curPos2 := match2.Pos(0) + match2.Len(0)
 				w := StrReplace(StrReplace(bodyText,"{","{",lB),"}","}",rB)
 				

--- a/LibV2/_ProcInfo.ahk
+++ b/LibV2/_ProcInfo.ahk
@@ -156,7 +156,7 @@ ProcInput() {
 	parentObjTypeList := Map()
 	For objName in ObjectList {
 		If (parentObj = objName) {
-			parentObjTypeList := ObjectList[objName]["types"]
+			parentObjTypeList := ObjectList[objName]["types"], parentObj := objName ; correct case on parentObj
 			Break
 		}
 	}


### PR DESCRIPTION
* fixed unintentional breakage of Notepad.exe compatibility
* ensured all call tips, auto-complete, and ProcInput() are disabled when Settings dialog is open
* fixed string function parameters showing up as *******